### PR TITLE
Make FS scan more robust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ where
             let mut objects = block.objects();
             while let Some(meta_object) = objects.next(&mut self.medium).await? {
                 match meta_object.state() {
-                    ObjectState::Free => break,
+                    ObjectState::Free | ObjectState::Corrupted => break,
                     ObjectState::Allocated => break,
                     ObjectState::Finalized => {}
                     ObjectState::Deleted => continue,
@@ -687,8 +687,8 @@ trait ObjectMover: Debug {
             while let Some(object) = iter.next(&mut storage.medium).await? {
                 match object.state() {
                     ObjectState::Free | ObjectState::Deleted => continue,
-                    ObjectState::Allocated => {
-                        log::warn!("Encountered an allocated object");
+                    ObjectState::Allocated | ObjectState::Corrupted => {
+                        log::warn!("Encountered object in incorrect state");
                         // TODO: retry in a different object
                         return Err(StorageError::InsufficientSpace);
                     }

--- a/src/ll/blocks.rs
+++ b/src/ll/blocks.rs
@@ -304,6 +304,7 @@ impl<M: StorageMedium> IndexedBlockInfo<M> {
             match object.state() {
                 ObjectState::Allocated | ObjectState::Deleted => deleted += object.total_size(),
                 ObjectState::Free | ObjectState::Finalized => {}
+                ObjectState::Corrupted => break,
             }
         }
 


### PR DESCRIPTION
This PR changes incorrect object handling so we won't immediately fail when we encounter an incorrect object. Incorrect objects may be present due to power loss, as the result of the following:

 - Power cuts out while deleting an object. The object may be located anywhere. If the object is not the last one, it should have a valid length.
 - Power cuts out while writing an object. The object will be the last one in the block. We may simply disallow allocating in the block. If we can prove that the object has a valid length that matches the used bytes in the block, we may treat the object as deleted.
 - Power cuts out while allocating an object. Same as above, but the incorrect byte may be the object's type, not it's state.

Additionally, we may have incorrect block headers, in case power cuts out while erasing a block. We should immediately reformat these blocks.

Related to #2 - I still don't know why the corruption happened (firmware locked up while writing a file, most likely), but we shouldn't completely trash the FS with this PR.