### PR TITLE
[wip] Directory support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ where
             }
 
             let meta_size =
-                ObjectHeader::byte_count::<M>() + 4 + (blocks + 1) * M::object_location_bytes();
+                ObjectHeader::byte_count::<M>() + 8 + (blocks + 1) * M::object_location_bytes();
 
             match self
                 .blocks
@@ -768,6 +768,12 @@ impl ObjectMover for DataObject {
             .write(
                 &mut storage.medium,
                 &old_object_reader.path_hash.to_le_bytes(),
+            )
+            .await?;
+        meta_writer
+            .write(
+                &mut storage.medium,
+                &old_object_reader.directory_hash.to_le_bytes(),
             )
             .await?;
 

--- a/src/ll/objects.rs
+++ b/src/ll/objects.rs
@@ -433,9 +433,9 @@ impl ObjectHeader {
 pub struct MetadataObjectHeader<M: StorageMedium> {
     pub object: ObjectHeader,
     pub path_hash: u32,
+    pub directory_hash: u32,
     pub filename_location: ObjectLocation,
     data_object_cursor: usize, // Used to iterate through the list of object locations.
-    _parent: Option<ObjectLocation>,
     _medium: PhantomData<M>,
 }
 
@@ -446,7 +446,7 @@ impl<M: StorageMedium> MetadataObjectHeader<M> {
     ) -> Result<Option<ObjectLocation>, StorageError> {
         log::trace!("MetadataObjectHeader::next_object_location()");
 
-        let data_offset = 4 + M::object_location_bytes(); // path hash + filename location
+        let data_offset = 4 + 4 + M::object_location_bytes(); // path hash + folder hash + filename location
         if self.data_object_cursor
             >= self
                 .object
@@ -776,13 +776,23 @@ impl<M: StorageMedium> ObjectInfo<M> {
             )
             .await?;
 
+        let mut directory_hash_bytes = [0; 4];
+        let directory_hash_offset = path_hash_offset + 4;
+        medium
+            .read(
+                self.location().block,
+                directory_hash_offset,
+                &mut directory_hash_bytes,
+            )
+            .await?;
+
         let mut filename_location_bytes = [0; 8];
         let filename_location_bytes = &mut filename_location_bytes[0..M::object_location_bytes()];
 
         medium
             .read(
                 self.location().block,
-                path_hash_offset + 4,
+                directory_hash_offset + 4,
                 filename_location_bytes,
             )
             .await?;
@@ -790,9 +800,9 @@ impl<M: StorageMedium> ObjectInfo<M> {
         Ok(MetadataObjectHeader {
             object: self.header,
             path_hash: u32::from_le_bytes(path_hash_bytes),
+            directory_hash: u32::from_le_bytes(directory_hash_bytes),
             filename_location: ObjectLocation::from_bytes::<M>(filename_location_bytes),
             data_object_cursor: 0,
-            _parent: None,
             _medium: PhantomData,
         })
     }

--- a/src/ll/objects.rs
+++ b/src/ll/objects.rs
@@ -12,6 +12,7 @@ use crate::{
 pub enum ObjectType {
     FileMetadata = 0x8F,
     FileData = 0x8E,
+    DirectoryMetadata = 0x8D,
 }
 
 impl ObjectType {
@@ -19,6 +20,7 @@ impl ObjectType {
         match byte {
             v if v == Self::FileMetadata as u8 => Some(Self::FileMetadata),
             v if v == Self::FileData as u8 => Some(Self::FileData),
+            v if v == Self::DirectoryMetadata as u8 => Some(Self::DirectoryMetadata),
             _ => None,
         }
     }


### PR DESCRIPTION
We can simulate directories by allowing `/` in the file paths. For directory iteration, we'll want to store the directory path hash in the file objects, so we can quickly reject objects. We need to introduce a new object type (Directory metadata) so we can create a hierarchy. Directories can't be renamed because that required renaming all contained files, recursively, but this is probably not that big of a limitation.